### PR TITLE
move-value-left

### DIFF
--- a/src/MCP48xx.h
+++ b/src/MCP48xx.h
@@ -91,7 +91,7 @@ void MCP48xx<BITS_RES>::setVoltage(uint16_t value, Channel channel) {
     if (value > (1u << BITS_RES) - 1) {
         value = (1u << BITS_RES) - 1;
     } else {
-        value = value >> (12u - BITS_RES);
+        value = value << (12u - BITS_RES);
     }
     command[channel] = command[channel] & 0xF000u;
     command[channel] = command[channel] | value;


### PR DESCRIPTION
The least significant bits should be zeroed. Moving them right just removes data.
Below see channel A working correctly. 
![DS1Z_QuickPrint2](https://user-images.githubusercontent.com/420735/100812065-0d3d5880-3434-11eb-86da-af972eaf275e.png)
